### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Scheduled Health Check
 
 # Controls when the action will run. This is set to run on a schedule using cron syntax.


### PR DESCRIPTION
Potential fix for [https://github.com/UdiaNIX/statuspage/security/code-scanning/1](https://github.com/UdiaNIX/statuspage/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and runs scripts, it does not need write access to repository contents or other resources. The best practice is to set `permissions: contents: read` at the top level of the workflow file, which will apply to all jobs unless overridden. This change should be made near the top of `.github/workflows/health-check.yml`, immediately after the `name` field and before the `on` block.

No additional methods, imports, or definitions are needed; this is a YAML configuration change only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
