### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Health Check and OCI Instance Restart
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/UdiaNIX/statuspage/security/code-scanning/10](https://github.com/UdiaNIX/statuspage/security/code-scanning/10)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code, installs dependencies, runs scripts, and uploads artifacts, it does not require any write permissions. The minimal required permission is `contents: read`, which allows the workflow to read repository contents. This block should be added at the top level of the workflow file (just after the `name:` line and before `on:`), so it applies to all jobs in the workflow. No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
